### PR TITLE
fix: Prevent deletion of last master node

### DIFF
--- a/frontend/src/views/ClusterWizard/ClusterWizardView.tsx
+++ b/frontend/src/views/ClusterWizard/ClusterWizardView.tsx
@@ -219,7 +219,7 @@ const ClusterWizardView = (props: Props) => {
             <div className="flex justify-start items-center">
                 <div className="text-4xl">K<span className="primary-text-color font-bold">4</span>Prox</div>
                 <span className="primary-text-color text-4xl mx-2">/</span>
-                <div className="text-3xl">Nodes</div>
+                <div className="text-3xl">Cluster planner</div>
             </div>
             <div className="flex items-center">
                 <p className="pi pi-server mr-2" style={{fontSize: "1.5rem"}}/>

--- a/frontend/src/views/ClusterWizard/Steps/Nodes/Sections/Properties/NodeProperties.tsx
+++ b/frontend/src/views/ClusterWizard/Steps/Nodes/Sections/Properties/NodeProperties.tsx
@@ -81,6 +81,13 @@ const NodeProperties = () => {
         }
     })
 
+    const canBeDeleted = () => {
+        if (projectStore.findNode(Number(uiPropertiesPanelStore.selectedPropertiesId))?.nodeType==="master") {
+            return projectStore.masterNodes.length > 1;
+        } else {
+            return true;
+        }
+    }
     const onDelete = () => {
         if (uiPropertiesPanelStore.selectedPropertiesId) {
             const id = uiPropertiesPanelStore.selectedPropertiesId;
@@ -178,7 +185,9 @@ const NodeProperties = () => {
                             <div className="mr-5">
                                 <Button disabled={!formik.isValid} type="submit" label="SAVE" className="p-button-primary"/>
                             </div>
-                            <Button onClick={onDelete} label="Delete"
+                            <Button onClick={onDelete}
+                                    disabled={!canBeDeleted()}
+                                    label="Delete"
                                     className="p-button-raised p-button-danger p-button-text"/>
                         </div>
                     </div>


### PR DESCRIPTION
At least one master node is required to perform cluster provisioning, creating orphan worker node is not support in cluster planner wizard.